### PR TITLE
Make getproperty non-allocating part 2

### DIFF
--- a/src/KLU.jl
+++ b/src/KLU.jl
@@ -389,7 +389,7 @@ function getproperty(klu::AbstractKLUFactorization{Tv, Ti}, s::Symbol) where {Tv
         s === :q && (s = :Q)
         s === :p && (s = :P)
         _extract!(klu; NamedTuple{(s,)}((out,))...)
-        if s ∈ [:Q, :P, :R]
+        if s ∈ (:Q, :P, :R)
             increment!(out)
         end
         return out


### PR DESCRIPTION
https://github.com/JuliaSparse/KLU.jl/pull/10 missed a vector of symbols

Can we please get a minor version release of this? @Wimmerer